### PR TITLE
Fix rsync

### DIFF
--- a/lib/gitsync.rb
+++ b/lib/gitsync.rb
@@ -35,7 +35,7 @@ class GitSync
       git.sh("#{Grit::Git.git_binary} --git-dir=#{git.git_dir} --work-tree=#{git.work_tree} reset --hard HEAD")
       git.sh("#{Grit::Git.git_binary} --git-dir=#{git.git_dir} --work-tree=#{git.work_tree} checkout #{branch_name}")
 
-      Rsync.run(local_repo, "#{basedir}/#{simple_branch_name}") do |result|
+      Rsync.run(local_repo, "#{basedir}/#{simple_branch_name}", ["-a --delete"]) do |result|
         if result.success?
           result.changes.each do |change|
             puts "#{change.filename} (#{change.summary})"

--- a/lib/gitsync.rb
+++ b/lib/gitsync.rb
@@ -35,7 +35,7 @@ class GitSync
       git.sh("#{Grit::Git.git_binary} --git-dir=#{git.git_dir} --work-tree=#{git.work_tree} reset --hard HEAD")
       git.sh("#{Grit::Git.git_binary} --git-dir=#{git.git_dir} --work-tree=#{git.work_tree} checkout #{branch_name}")
 
-      Rsync.run(local_repo, "#{basedir}/#{simple_branch_name}", ["-a --delete"]) do |result|
+      Rsync.run("#{local_repo}/puppet/", "#{basedir}/#{simple_branch_name}", ["-a --delete"]) do |result| 
         if result.success?
           result.changes.each do |change|
             puts "#{change.filename} (#{change.summary})"


### PR DESCRIPTION
Repo structure contains `puppet/{hiera|manifests|modules}` directories, only rsync this portion to puppet environments
